### PR TITLE
50 arduino nano

### DIFF
--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -12,7 +12,7 @@ from .rov_state import ROVState
 
 SERVER_IP = "192.168.0.102"  # raspberry pi ip
 PORT = 2049
-ARDUINO_PORT = "/dev/ttyACM0"
+ARDUINO_PORT = "/dev/ttyUSB0"
 
 if os.environ.get("SIM"):
     from .sim_hardware import SimThruster

--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -77,7 +77,7 @@ class Server:
         self.loop.close()
 
     def _init_firmata(self):
-        self.board = pyfirmata.ArduinoMega(ARDUINO_PORT)
+        self.board = pyfirmata.ArduinoNano(ARDUINO_PORT)
         print("Successfully connected to Arduino")
         it = pyfirmata.util.Iterator(self.board)
         it.start()


### PR DESCRIPTION
### Description

this pr addresses ticket #50, testing the feasibility of replacing the arduino mega with an arduino nano. the only code changes are initializing the arduino as an instance of an arduino nano rather than a mega and changing the port the arduino is on, as the nano connects to a different port than the mega. the bulk of this ticket was testing.

### Testing Performed

first, i verified that async_server would run with the code changes -- i.e. pyfirmata played nice with the nano on the pi end. then, i hooked the nano up to a servo and moved it using async_server. this should be sufficient to prove that the pi can properly communicate with the nano through pyfirmata to send pwm signals.

### Documentation

no documentation was needed, as only two lines of code were changed, and they're pretty self-describing.

### Pre-PR Review Checklist

All of the following must be completed before a PR comes out of draft:
- [x] Changes less than 500 LOC. Anything greater must be broken into multiple PRs.
- [x] Code self-review has been performed.
- [x] Changes have been tested on all relevant hardware.
- [x] This base branch of this PR is the most appropriate for showcasing the changes.