### PR TITLE
rate-limit pwm changes (#60)

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -181,9 +181,10 @@ class PIDController:
         return output
 
 class SlewRateLimiter:
-    def __init__(self, max_rate, initial_value=0.0):
+    def __init__(self, max_rate, initial_value, min_value):
         self.max_rate = max_rate   # Maximum rate of change
         self.last_value = initial_value
+        self.min_value = min_value
 
     def update(self, target_value, dt):
         """Update the slew rate limiter.
@@ -198,4 +199,8 @@ class SlewRateLimiter:
         if abs(change) > max_change:
             change = max_change * (1 if change > 0 else -1)
         self.last_value += change
+
+        if self.min_value is not None:
+            self.last_value = max(self.last_value, self.min_value)
+        
         return self.last_value

--- a/common/utils.py
+++ b/common/utils.py
@@ -179,3 +179,23 @@ class PIDController:
         self.last_error = error
         self.last_output = output
         return output
+
+class SlewRateLimiter:
+    def __init__(self, max_rate_per_sec, initial_value=0.0):
+        self.max_rate = max_rate_per_sec   # Maximum rate of change
+        self.last_value = initial_value
+
+    def update(self, target_value, dt):
+        """Update the slew rate limiter.
+        Args:
+            target_value (float): target value to limit
+            dt (float): time since last update (seconds)
+        Returns:
+            float: limited value
+        """
+        change = target_value - self.last_value
+        max_change = self.max_rate * dt
+        if abs(change) > max_change:
+            change = max_change * (1 if change > 0 else -1)
+        self.last_value += change
+        return self.last_value

--- a/common/utils.py
+++ b/common/utils.py
@@ -181,11 +181,11 @@ class PIDController:
         return output
 
 class SlewRateLimiter:
-    def __init__(self, max_rate, initial_value):
+    def __init__(self, max_rate: float, initial_value: float):
         self.max_rate = max_rate   # Maximum rate of change
         self.last_value = initial_value
 
-    def update(self, target_value, dt):
+    def update(self, target_value: float, dt: float):
         """Update the slew rate limiter.
         Args:
             target_value (float): target value to limit
@@ -196,7 +196,7 @@ class SlewRateLimiter:
         change = target_value - self.last_value
         max_change = self.max_rate * dt
         if abs(change) > max_change:
-            change = max_change * (1 if change > 0 else -1)
+            change = max_change * (1.0 if change > 0.0 else -1.0)
         self.last_value += change
         
         return self.last_value

--- a/common/utils.py
+++ b/common/utils.py
@@ -181,8 +181,8 @@ class PIDController:
         return output
 
 class SlewRateLimiter:
-    def __init__(self, max_rate_per_sec, initial_value=0.0):
-        self.max_rate = max_rate_per_sec   # Maximum rate of change
+    def __init__(self, max_rate, initial_value=0.0):
+        self.max_rate = max_rate   # Maximum rate of change
         self.last_value = initial_value
 
     def update(self, target_value, dt):

--- a/common/utils.py
+++ b/common/utils.py
@@ -181,10 +181,9 @@ class PIDController:
         return output
 
 class SlewRateLimiter:
-    def __init__(self, max_rate, initial_value, min_value):
+    def __init__(self, max_rate, initial_value):
         self.max_rate = max_rate   # Maximum rate of change
         self.last_value = initial_value
-        self.min_value = min_value
 
     def update(self, target_value, dt):
         """Update the slew rate limiter.
@@ -199,8 +198,5 @@ class SlewRateLimiter:
         if abs(change) > max_change:
             change = max_change * (1 if change > 0 else -1)
         self.last_value += change
-
-        if self.min_value is not None:
-            self.last_value = max(self.last_value, self.min_value)
         
         return self.last_value

--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -194,7 +194,7 @@ class Server:
                 )
 
             if "status_flags" in json_msg:
-                self.rov_state.set_status_flags(json.loads(json_msg["status_flags"]))
+                self.rov_state.set_status_flags(dict(json.loads(json_msg["status_flags"])))
 
             if "imu_data" in json_msg:
                 self.rov_state.set_current_imu_data(

--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -11,7 +11,7 @@ from common import utils
 from .hardware import Servo, Thruster, LinActuator
 from .rov_state import ROVState
 
-SERVER_IP = "192.168.0.111"  # raspberry pi ip
+SERVER_IP = "192.168.0.102"  # raspberry pi ip
 PORT = 2049
 ARDUINO_PORT = "/dev/ttyUSB0"
 RESPONSE_LOOP_FREQ = 10 # Hz
@@ -48,10 +48,10 @@ class Server:
                     "front_right_horizontal": Thruster(self._get_pin(4, "s"), active_range=(1250, 1750)),
                     "back_left_horizontal": Thruster(self._get_pin(6, "s"), active_range=(1250, 1750)),
                     "back_right_horizontal": Thruster(self._get_pin(8, "s"), active_range=(1250, 1750)),
-                    "front_left_vertical": Thruster(self._get_pin(3, "s")),
+                    "front_left_vertical": Thruster(self._get_pin(3, "s"), reverse=True),
                     "front_right_vertical": Thruster(self._get_pin(5, "s"), reverse=True),
                     "back_left_vertical": Thruster(self._get_pin(7, "s"), reverse=True),
-                    "back_right_vertical": Thruster(self._get_pin(9, "s")),
+                    "back_right_vertical": Thruster(self._get_pin(9, "s"), reverse=True),
                 },
                 sensors={
 

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -56,7 +56,7 @@ class ROVState:
         self._slew_limiters = {}
         for name, _ in self.thrusters.items():
             self._slew_limiters[name] = SlewRateLimiter(
-                max_rate = (2.0 / 10.0), 
+                max_rate = (2.0 / 1.0), 
                 initial_value = 0.0
             )
 

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -52,9 +52,14 @@ class ROVState:
         self._bang_bang_radius = 0.02 # distance in meters from target depth before turning on
         self._p_factor = 1 # factor to scale the auto-depth by
         self._slew_limiters = {}
-        for name, thruster in self.thrusters.items():
-            self._slew_limiters[name] = SlewRateLimiter(
-                max_rate_of_change=(thruster.active_range[1] - thruster.active_range[0]) # max rate of change per second
+        # for name, thruster in self.thrusters.items():
+        #     self._slew_limiters[name] = SlewRateLimiter(
+        #         max_rate==(thruster.active_range[1] - thruster.active_range[0]) # max rate of change per second
+        #     )
+
+        for axis in self._current_velocity.keys():
+            self._slew_limiters[axis] = SlewRateLimiter(
+                max_rate=500  # max rate of change per second for velocity axes
             )
 
     def get_tasks(self) -> list[asyncio.Task]:
@@ -213,6 +218,7 @@ class ROVState:
                 output_velocity = self._target_velocity
             
             # apply slew rate limiters to output velocity
+            # TODO: reconcile axis with thrusters- are they somehow compatible? can we use them interchangeably?
             slewed_velocity = VelocityVector()
             for axis in output_velocity.keys():
                 slewed_velocity[axis] = self._slew_limiters[axis].update(

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -54,7 +54,7 @@ class ROVState:
         self._slew_limiters = {}
         for name, thruster in self.thrusters.items():
             self._slew_limiters[name] = SlewRateLimiter(
-                max_rate=(thruster.active_range[1] - thruster.active_range[0]) # max rate of change per second
+                max_rate=((thruster.active_range[1] - thruster.active_range[0]) / 10) # max rate of change per second
             )
 
         # for axis in self._current_velocity.keys():

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -54,7 +54,9 @@ class ROVState:
         self._slew_limiters = {}
         for name, thruster in self.thrusters.items():
             self._slew_limiters[name] = SlewRateLimiter(
-                max_rate=((thruster.active_range[1] - thruster.active_range[0]) / 10) # max rate of change per second
+                max_rate = ((thruster.active_range[1] - thruster.active_range[0]) / 10), 
+                initial_value = thruster.angle,
+                min_value = thruster.active_range[0]
             )
 
         # for axis in self._current_velocity.keys():

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -103,11 +103,11 @@ class ROVState:
             mix["back_right_vertical"] *= self.status_flags["agnes_factor"]
         
         # apply slew rate limiters to thruster mix
-            for name, value in mix.items():
-                if name in self._slew_limiters:
-                    mix[name] = self._slew_limiters[name].update(value, dt)
-                else:
-                    logging.warning(f"Slew rate limiter for {name} not found, using raw value.")
+        for name, value in mix.items():
+            if name in self._slew_limiters:
+                mix[name] = self._slew_limiters[name].update(value, dt)
+            else:
+                logging.warning(f"Slew rate limiter for {name} not found, using raw value.")
 
         # cap value to [-1, 1]
         for name, value in mix.items():

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -171,14 +171,20 @@ class ROVState:
             # update last time
             self._last_time = time_ms()
 
+            if -0.1 < self._target_velocity.z < 0.1:
+                self._target_depth -= self._target_velocity.z * self._z_sensitivity
+                # test different sensitivities and potentially functions
+                if self._target_depth > 1 and self._current_depth > 1:
+                    self._target_velocity.z = (self._target_depth - self._current_depth) ** 3
+
             # Plan test these and either make them toggleable or keep the best one
             # Auto Depth V1 (Bang Bang P)
-            if self.status_flags["auto_depth"]:
-                if abs(self._target_depth - self._current_depth) > self._bang_bang_radius:
-                    self._target_velocity.z = ((self._target_depth - self._current_depth) * 
-                                               self._p_factor)
-                else: 
-                    self._target_velocity.z = 0
+            # if self.status_flags["auto_depth"]:
+            #     if abs(self._target_depth - self._current_depth) > self._bang_bang_radius:
+            #         self._target_velocity.z = ((self._target_depth - self._current_depth) * 
+            #                                    self._p_factor)
+            #     else: 
+            #         self._target_velocity.z = 0
 
             # Auto Depth V2 (Pure Bang Bang)
             # if self.status_flags["auto_depth"]:

--- a/pi/rov_state.py
+++ b/pi/rov_state.py
@@ -42,7 +42,7 @@ class ROVState:
             self._pid_controllers[axis] = PIDController(
                 kp=1.0, ki=0.1, kd=0.01, max_output=90, max_rate_of_change=180
             )
-        self._control_loop_frequency = 10  # Hz
+        self._control_loop_frequency = 10.0  # Hz
         self._last_time = time_ms()  # time the last control loop iteration was executed in ms
         self._last_current_velocity_update = 0  # time of last current velocity update in ms
         self._last_current_claw_update = 0  # time of last current claw update in ms
@@ -57,7 +57,7 @@ class ROVState:
         for name, _ in self.thrusters.items():
             self._slew_limiters[name] = SlewRateLimiter(
                 max_rate = (2.0 / 10.0), 
-                initial_value = 0
+                initial_value = 0.0
             )
 
         # for axis in self._current_velocity.keys():
@@ -171,10 +171,10 @@ class ROVState:
 
     async def control_loop(self):
         """Control loop."""
-        loop_period = 1000 / self._control_loop_frequency  # ms
+        loop_period = 1000.0 / self._control_loop_frequency  # ms
 
         while True:
-            dt = (time_ms() - self._last_time) / 1000
+            dt = float(time_ms() - self._last_time) / 1000.0
             # update last time
             self._last_time = time_ms()
 

--- a/surface/surface_client.py
+++ b/surface/surface_client.py
@@ -57,7 +57,7 @@ class SurfaceClient:
             msg = { 
                 "target_velocity": json.dumps(velocity_vec.to_dict()),
                 "claw_movement": json.dumps(claw_vec),
-                "status_flags": json.dumps(status_flags)
+                "status_flags": json.dumps(status_flags),
             }
             writer.write(str.encode(json.dumps(msg)))
             await writer.drain()


### PR DESCRIPTION
rate-limiting pwm changes. slew rate is limited to the thrusters' full range over the course of 1 second. also fixes some style things and debugs comms between surface client and async server.