### PR TITLE
Add delimiters

### DIFF
--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -131,7 +131,8 @@ class Server:
             print(f"received first message: {msg}")
             while msg:
                 async with self.lock:
-                    self.incoming.append(msg)
+                    for spl in msg.split("~"):
+                        self.incoming.append(spl)
                     self.last_update = utils.time_ms()
                 msg = (await reader.read(1024)).decode("utf-8")
             print("client disconnected, closing parser")

--- a/pi/async_server.py
+++ b/pi/async_server.py
@@ -132,7 +132,8 @@ class Server:
             while msg:
                 async with self.lock:
                     for spl in msg.split("~"):
-                        self.incoming.append(spl)
+                        if (spl.strip() != ""):
+                            self.incoming.append(spl)
                     self.last_update = utils.time_ms()
                 msg = (await reader.read(1024)).decode("utf-8")
             print("client disconnected, closing parser")

--- a/pi/depth-sensor.py
+++ b/pi/depth-sensor.py
@@ -62,7 +62,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             msg = {
                 "depth": json.dumps(depth_list),
             }
-            s.send(str.encode(json.dumps(msg)))
+            s.send(str.encode(json.dumps(msg) + "~"))
             print(f"sent: {msg}")
         except Exception as err:
             print("Error encountered in depth sensor client execution: " + str(err))

--- a/pi/imu.py
+++ b/pi/imu.py
@@ -99,7 +99,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 "imu_data": json.dumps(data),
             }
             
-            s.send(str.encode(json.dumps(msg)))
+            s.send(str.encode(json.dumps(msg) + "~"))
 
             print(f"sent: {msg}")
         except RuntimeError as err:

--- a/surface/surface_client.py
+++ b/surface/surface_client.py
@@ -59,7 +59,7 @@ class SurfaceClient:
                 "claw_movement": json.dumps(claw_vec),
                 "status_flags": json.dumps(status_flags),
             }
-            writer.write(str.encode(json.dumps(msg)))
+            writer.write(str.encode(json.dumps(msg) + "~"))
             await writer.drain()
             print(f"sent: {msg}")
 


### PR DESCRIPTION
Adds a delimiter (~) to messages sent to async server to prevent parsing errors when messages are sent too rapidly for the reader to read one at a time.